### PR TITLE
add sha256t used by onecoin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -77,6 +77,7 @@ cpuminer_SOURCES = \
   algo/drop.c \
   algo/echo/aes_ni/hash.c\
   algo/fresh.c \
+  algo/sha256t.c\
   algo/groestl/groestl.c \
   algo/groestl/myr-groestl.c \
   algo/groestl/aes_ni/hash-groestl.c \

--- a/algo-gate-api.c
+++ b/algo-gate-api.c
@@ -169,6 +169,7 @@ bool register_algo_gate( int algo, algo_gate_t *gate )
      case ALGO_DEEP:        register_deep_algo       ( gate ); break;
      case ALGO_DROP:        register_drop_algo       ( gate ); break;
      case ALGO_FRESH:       register_fresh_algo      ( gate ); break;
+     case ALGO_SHA256T:     register_sha256t_algo    ( gate ); break;
      case ALGO_GROESTL:     register_groestl_algo    ( gate ); break;
      case ALGO_HEAVY:       register_heavy_algo      ( gate ); break;
      case ALGO_HMQ1725:     register_hmq1725_algo    ( gate ); break;

--- a/algo/sha256t.c
+++ b/algo/sha256t.c
@@ -1,0 +1,139 @@
+#include "miner.h"
+#include "algo-gate-api.h"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "sha3/sph_sha2.h"
+
+//#define DEBUG_ALGO
+
+/* Move init out of loop, so init once externally, and then use one single memcpy with that bigger memory block */
+typedef struct {
+	sph_sha256_context	sha256;
+} sha256t_context_holder;
+
+/* no need to copy, because close reinit the context */
+static  sha256t_context_holder ctx __attribute__ ((aligned (64)));
+
+void init_sha256t_contexts(void *dummy)
+{
+	sph_sha256_init(&ctx.sha256);
+}
+
+
+void sha256t_hash(void* output, const void* input,  uint32_t len)
+{
+        sph_sha256_context      ctx_sha256 __attribute__ ((aligned (64)));
+	uint32_t _ALIGN(64) hashA[16];
+
+        sph_sha256_init(&ctx_sha256);
+	sph_sha256 (&ctx_sha256, input, 80);
+	sph_sha256_close(&ctx_sha256, hashA);
+
+        sph_sha256_init(&ctx_sha256);
+	sph_sha256 (&ctx_sha256, hashA, 32);
+	sph_sha256_close(&ctx_sha256, hashA);
+
+        sph_sha256_init(&ctx_sha256);
+	sph_sha256 (&ctx_sha256, hashA, 32);
+	sph_sha256_close(&ctx_sha256, hashA);
+
+	memcpy(output, hashA, 32);
+
+}
+
+int scanhash_sha256t(int thr_id, struct work *work,
+				uint32_t max_nonce, uint64_t *hashes_done)
+{
+        uint32_t *pdata = work->data;
+        uint32_t *ptarget = work->target;
+	uint32_t len = 80;
+
+	uint32_t n = pdata[19] - 1;
+	const uint32_t first_nonce = pdata[19];
+	const uint32_t Htarg = ptarget[7];
+#ifdef _MSC_VER
+	uint32_t __declspec(align(32)) hash64[8];
+#else
+	uint32_t hash64[8] __attribute__((aligned(32)));
+#endif
+	uint32_t endiandata[32];
+
+	uint64_t htmax[] = {
+		0,
+		0xF,
+		0xFF,
+		0xFFF,
+		0xFFFF,
+		0x10000000
+	};
+	uint32_t masks[] = {
+		0xFFFFFFFF,
+		0xFFFFFFF0,
+		0xFFFFFF00,
+		0xFFFFF000,
+		0xFFFF0000,
+		0
+	};
+
+	// we need bigendian data...
+        for (int k = 0; k < 19; k++)
+                be32enc(&endiandata[k], pdata[k]);
+
+#ifdef DEBUG_ALGO
+	if (Htarg != 0)
+		printf("[%d] Htarg=%X\n", thr_id, Htarg);
+#endif
+	for (int m=0; m < 6; m++) {
+		if (Htarg <= htmax[m]) {
+			uint32_t mask = masks[m];
+			do {
+				pdata[19] = ++n;
+				be32enc(&endiandata[19], n);
+				sha256t_hash(hash64, endiandata, len);
+#ifndef DEBUG_ALGO
+				if ((!(hash64[7] & mask)) && fulltest(hash64, ptarget)) {
+					*hashes_done = n - first_nonce + 1;
+					return true;
+				}
+#else
+				if (!(n % 0x1000) && !thr_id) printf(".");
+				if (!(hash64[7] & mask)) {
+					printf("[%d]",thr_id);
+					if (fulltest(hash64, ptarget)) {
+						*hashes_done = n - first_nonce + 1;
+						return true;
+					}
+				}
+#endif
+			} while (n < max_nonce && !work_restart[thr_id].restart);
+			// see blake.c if else to understand the loop on htmax => mask
+			break;
+		}
+	}
+
+	*hashes_done = n - first_nonce + 1;
+	pdata[19] = n;
+	return 0;
+}
+
+void sha256t_set_target( struct work* work, double job_diff )
+{
+ work_set_target( work, job_diff / (256.0 * opt_diff_factor) );
+}
+
+
+bool register_sha256t_algo( algo_gate_t* gate )
+{
+    algo_not_tested();
+    gate->scanhash   = (void*)&scanhash_sha256t;
+    gate->hash       = (void*)&sha256t_hash;
+    gate->hash_alt   = (void*)&sha256t_hash;
+    gate->set_target = (void*)&sha256t_set_target;
+    gate->get_max64  = (void*)&get_max64_0x3ffff;
+    return true;
+};
+

--- a/miner.h
+++ b/miner.h
@@ -489,6 +489,7 @@ enum algos {
         ALGO_DEEP,
         ALGO_DROP,        
         ALGO_FRESH,       
+	ALGO_SHA256T,
         ALGO_GROESTL,     
         ALGO_HEAVY,
         ALGO_HMQ1725,
@@ -549,6 +550,7 @@ static const char* const algo_names[] = {
         "deep",
         "drop",
         "fresh",
+	"sha256t",
         "groestl",
         "heavy",
         "hmq1725",
@@ -664,6 +666,7 @@ Options:\n\
                           deep         Deepcoin (DCN)\n\
                           drop         Dropcoin\n\
                           fresh        Fresh\n\
+			  sha256t      SHA256T\n\
                           groestl      groestl\n\
                           heavy        Heavy\n\
                           hmq1725      Espers\n\


### PR DESCRIPTION
This PR adds support for triple sha256 which is used by onecoin (oc):
https://bitcointalk.org/index.php?topic=1801129
