### PR TITLE
Enable compilation on FreeBSD

### DIFF
--- a/algo/hodl/sha512_avx.c
+++ b/algo/hodl/sha512_avx.c
@@ -4,6 +4,9 @@
 //Dependencies
 #include <string.h>
 #include <stdlib.h>
+#ifdef __FreeBSD__
+#include <sys/endian.h>
+#endif
 #include "tmmintrin.h"
 #include "smmintrin.h"
 

--- a/algo/hodl/sha512_avx2.c
+++ b/algo/hodl/sha512_avx2.c
@@ -3,6 +3,9 @@
 //Dependencies
 #include <string.h>
 #include <stdlib.h>
+#ifdef __FreeBSD__
+#include <sys/endian.h>
+#endif
 #include "tmmintrin.h"
 #include "smmintrin.h"
 #include "immintrin.h"


### PR DESCRIPTION
The current code does not allow compiling on FreeBSD, due to missing headers. I added them, it compiles successfully with GCC6.

I did not, however, tried mining HODL to see if it has any adverse effets. YMMV.