### PR TITLE
Adding keccakc (creativecoin) support

### DIFF
--- a/algo-gate-api.c
+++ b/algo-gate-api.c
@@ -171,6 +171,7 @@ bool register_algo_gate( int algo, algo_gate_t *gate )
      case ALGO_HODL:         register_hodl_algo        ( gate ); break;
      case ALGO_JHA:          register_jha_algo         ( gate ); break;
      case ALGO_KECCAK:       register_keccak_algo      ( gate ); break;
+     case ALGO_KECCAKC:      register_keccakc_algo     ( gate ); break;
      case ALGO_LBRY:         register_lbry_algo        ( gate ); break;
      case ALGO_LUFFA:        register_luffa_algo       ( gate ); break;
      case ALGO_LYRA2RE:      register_lyra2re_algo     ( gate ); break;

--- a/algo/keccak/keccak-gate.c
+++ b/algo/keccak/keccak-gate.c
@@ -24,4 +24,28 @@ bool register_keccak_algo( algo_gate_t* gate )
   return true;
 };
 
+void keccakc_set_target( struct work* work, double job_diff )
+{
+  work_set_target( work, job_diff / (256.0 * opt_diff_factor) );
+}
+
+int64_t keccakc_get_max64() { return 0x7ffffLL; }
+
+bool register_keccakc_algo( algo_gate_t* gate )
+{
+  gate->gen_merkle_root = (void*)&sha256d_gen_merkle_root;
+  gate->set_target      = (void*)&keccak_set_target;
+  gate->get_max64       = (void*)&keccak_get_max64;
+#if defined (KECCAK_4WAY)
+  gate->optimizations = SSE2_OPT | AVX2_OPT;
+  gate->scanhash  = (void*)&scanhash_keccak_4way;
+  gate->hash      = (void*)&keccakhash_4way;
+#else
+  gate->optimizations = SSE2_OPT;
+  gate->scanhash        = (void*)&scanhash_keccak;
+  gate->hash            = (void*)&keccakhash;
+#endif
+  return true;
+};
+
 

--- a/miner.h
+++ b/miner.h
@@ -499,6 +499,7 @@ enum algos {
         ALGO_HODL,
         ALGO_JHA,
         ALGO_KECCAK,
+        ALGO_KECCAKC,
         ALGO_LBRY,
         ALGO_LUFFA,       
         ALGO_LYRA2RE,       
@@ -568,6 +569,7 @@ static const char* const algo_names[] = {
         "hodl",
         "jha",
         "keccak",
+        "keccakc",
         "lbry",
         "luffa",
         "lyra2re",
@@ -691,6 +693,7 @@ Options:\n\
                           hodl         Hodlcoin\n\
                           jha          jackppot (Jackpotcoin)\n\
                           keccak       Keccak\n\
+                          keccakc      KeccakC (Creativecoin)\n\
                           lbry         LBC, LBRY Credits\n\
                           luffa        Luffa\n\
                           lyra2re      lyra2\n\


### PR DESCRIPTION
This is a very quick implementation of the keccakc variant for
creativecoin, which involves sha256d instead of sha256.

This patch is inspired by dan-and's patch in [1] and valided by mining
coins for the pool yiimp.eu, which worked at doubled rate compared to
cpuminer-multi (both compiled with -march=native).

[1] https://github.com/tpruvot/cpuminer-multi/pull/21/files