### PR TITLE
Add original (w/o client key hack) yescrypt for BitZeny

### DIFF
--- a/algo-gate-api.c
+++ b/algo-gate-api.c
@@ -219,6 +219,7 @@ bool register_algo_gate( int algo, algo_gate_t *gate )
      case ALGO_X17:          register_x17_algo         ( gate ); break;
      case ALGO_XEVAN:        register_xevan_algo       ( gate ); break;
      case ALGO_YESCRYPT:     register_yescrypt_algo    ( gate ); break;
+     case ALGO_YESCRYPTR8:   register_yescryptr8_algo  ( gate ); break;
      case ALGO_YESCRYPTR16:  register_yescryptr16_algo ( gate ); break;
      case ALGO_ZR5:          register_zr5_algo         ( gate ); break;
     default:
@@ -303,7 +304,7 @@ const char* const algo_alias_map[][2] =
   { "yes",               "yescrypt"     },
   { "ziftr",             "zr5"          },
   { "yenten",            "yescryptr16"  },
-  { "yescryptr8",        "yescrypt"     },
+  { "bitzeny",           "yescryptr8"   },
   { "zcoin",             "lyra2z"       },
   { "zoin",              "lyra2z330"    },
   { NULL,                NULL           }   

--- a/algo/yescrypt/yescrypt.c
+++ b/algo/yescrypt/yescrypt.c
@@ -438,6 +438,20 @@ bool register_yescrypt_algo( algo_gate_t* gate )
    return true;
 }
 
+bool register_yescryptr8_algo( algo_gate_t* gate )
+{
+   gate->optimizations = SSE2_OPT | SHA_OPT;
+   gate->scanhash   = (void*)&scanhash_yescrypt;
+   gate->hash       = (void*)&yescrypt_hash;
+   gate->set_target = (void*)&scrypt_set_target;
+   gate->get_max64  = (void*)&yescrypt_get_max64;
+   client_key_hack = false;
+   YESCRYPT_N = 2048;
+   YESCRYPT_R = 8;
+   YESCRYPT_P = 1;
+   return true;
+}
+
 bool register_yescryptr16_algo( algo_gate_t* gate )
 {
    gate->optimizations = SSE2_OPT | SHA_OPT;

--- a/miner.h
+++ b/miner.h
@@ -546,6 +546,7 @@ enum algos {
         ALGO_X17,
         ALGO_XEVAN,
         ALGO_YESCRYPT,
+        ALGO_YESCRYPTR8,
         ALGO_YESCRYPTR16,
         ALGO_ZR5,
         ALGO_COUNT
@@ -617,6 +618,7 @@ static const char* const algo_names[] = {
         "x17",
         "xevan",
         "yescrypt",
+        "yescryptr8",
         "yescryptr16",
         "zr5",
         "\0"
@@ -743,6 +745,7 @@ Options:\n\
                           x17\n\
                           xevan        Bitsend\n\
                           yescrypt     Globlboost-Y (BSTY)\n\
+                          yescryptr8   BitZeny (ZNY)\n\
                           yescryptr16  Yenten (YTN)\n\
                           zr5          Ziftr\n\
   -o, --url=URL         URL of mining server\n\


### PR DESCRIPTION
This PR enables the users to use original (`client_key_hack = false`) yescrypt algorithm by `-a yescryptr8`. The algo is used to mine BitZeny (ZNY).

One concern is that the name `yescryptr8` is previously used as an alias of `yes:crypt` (BSTY's) so it breaks backward compatibility. But I think it's intuitive when thinking as follows
 - `yescrypt`: client_key hacked yescrypt (R=8)
 - `yescryptr8`: client_key **un**hacked yescrypt (R=8)
 - `yescryptr16`: client_key **un**hacked yescrypt (R=16)

so `yescryptrN` (N: number) indicates client_key unhacked. (well, there's the problem to how to name hacked R=16 yescrypt. Maybe `yescrypt16`?)

Of course, I'm for to change the name if you won't like above option 🙂 
  