### PR TITLE
Add solution counting to API.

### DIFF
--- a/api.c
+++ b/api.c
@@ -96,6 +96,7 @@ extern char *opt_api_allow;
 extern int opt_api_listen; /* port */
 extern int opt_api_remote;
 extern double global_hashrate;
+extern uint32_t solved_count;
 extern uint32_t accepted_count;
 extern uint32_t rejected_count;
 
@@ -156,12 +157,12 @@ static char *getsummary(char *params)
 
 	*buffer = '\0';
 	sprintf(buffer, "NAME=%s;VER=%s;API=%s;"
-		"ALGO=%s;CPUS=%d;KHS=%.2f;ACC=%d;REJ=%d;"
+		"ALGO=%s;CPUS=%d;KHS=%.2f;SOLV=%u;ACC=%d;REJ=%d;"
 		"ACCMN=%.3f;DIFF=%s;TEMP=%.1f;FAN=%d;FREQ=%d;"
 		"UPTIME=%.0f;TS=%u|",
 		PACKAGE_NAME, PACKAGE_VERSION, APIVERSION,
 		algo, opt_n_threads, (double)global_hashrate / 1000.0,
-		accepted_count, rejected_count, accps, diff_str,
+		solved_count, accepted_count, rejected_count, accps, diff_str,
 		cpu.cpu_temp, cpu.cpu_fan, cpu.cpu_clock,
 		uptime, (uint32_t) ts);
 	return buffer;

--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -138,6 +138,7 @@ double opt_diff_factor = 1.0;
 uint32_t zr5_pok = 0;
 bool opt_stratum_stats = false;
 
+uint32_t solved_count = 0L;
 uint32_t accepted_count = 0L;
 uint32_t rejected_count = 0L;
 double *thr_hashrates;
@@ -782,6 +783,7 @@ static int share_result( int result, struct work *work, const char *reason )
    global_hashcount = hashcount;
    global_hashrate = hashrate;
    total_submits = accepted_count + rejected_count;
+   if( net_diff || sharediff > net_diff ) solved_count++;
 
    rate = ( result ? ( 100. * accepted_count / total_submits )  
                    : ( 100. * rejected_count / total_submits ) );


### PR DESCRIPTION
It's a little QoL improvement. I basically just stole the logic from ccminer. I also changed a couple of _related_ types and format specifiers because I can't see any valid reason for e.g. the accepted/rejected counts to _ever_ be negative, and they get converted to uint32_h anyway for the API.