### PR TITLE
Add CPU group support to cpuminer-opt

### DIFF
--- a/miner.h
+++ b/miner.h
@@ -694,6 +694,7 @@ extern bool allow_mininginfo;
 extern time_t g_work_time;
 extern bool opt_stratum_stats;
 extern int num_cpus;
+extern int num_cpugroups;
 extern int opt_priority;
 
 extern pthread_mutex_t rpc2_job_lock;

--- a/mingw64.sh
+++ b/mingw64.sh
@@ -10,7 +10,7 @@ extracflags="-O3 -Wall -D_REENTRANT -fmerge-all-constants" # -funroll-loops -fva
 # extracflags="$extracflags -Ofast -fuse-linker-plugin -ftree-loop-if-convert-stores" # -flto "
 
 # extracflags="-pg -static -fno-inline-small-functions"
-CFLAGS="-DCURL_STATICLIB -DOPENSSL_NO_ASM -DUSE_ASM $extracflags"
+CFLAGS="-D_WIN32_WINNT=0x0601 -DCURL_STATICLIB -DOPENSSL_NO_ASM -DUSE_ASM $extracflags"
 # CPPFLAGS=""
 
 # icon


### PR DESCRIPTION
Several people have complained that multi-socket is not correctly supported by cpuminer-opt, this is due to the fact that Windows will create CPU groups when the total core count goes above 64 but it also does this in (some?) cases when you have mutliple sockets.

This PR will add support for CPU groups for Windows.

It does require you to define _WIN32_WINNT=0x0601 (this will break support for Windows versions below 2008R2 and Windows 7) , without it you will not have access to the group-functions. I added the define to mingw64.sh , I'm not a buildscript wizard, so not entirely sure if that's the right place to define it (it's probably better off somewhere else).

Tested this on a Dual Socket E5-2696v3 server, without this it'll only see 36 cores, with this patch it'll see the correct 72 cores. It'll also go from 370H/s on cryptonight to 736H/s on cryptonight. This is still shy a few 100H/s compared to xmr-stak though 😢   

The CPU usage will also nicely go from 50% to 100% .