### PR TITLE
.travis.yml: Add -fno-common to CFLAGS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ before_script:
 
 script:
   - ./configure --with-crypto --with-curl
-  - make
+  - make CFLAGS="-fno-common"
   - ./cpuminer --cputest


### PR DESCRIPTION
-fno-common will be set by default in GCC 10, see https://gcc.gnu.org/PR85678

Therefore, cpuminer-opt should test with that configuration to be ready for this change.

See https://github.com/JayDDee/cpuminer-opt/issues/232