### PR TITLE
docs: fix simple typo, prarallel -> parallel

### DIFF
--- a/algo/quark/hmq1725-4way.c
+++ b/algo/quark/hmq1725-4way.c
@@ -912,7 +912,7 @@ extern void hmq1725_4way_hash(void *state, const void *input)
    sph_whirlpool512_full( &ctx.whirlpool, hash2, hash2, 64 );
    sph_whirlpool512_full( &ctx.whirlpool, hash3, hash3, 64 );
 
-// A = fugue serial, B = sha512 prarallel
+// A = fugue serial, B = sha512 parallel
    
    intrlv_4x64( vhash, hash0, hash1, hash2, hash3, 512 );
 


### PR DESCRIPTION
There is a small typo in algo/quark/hmq1725-4way.c.

Should read `parallel` rather than `prarallel`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md