### PR TITLE
Fix linking with gcc 9.3.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -303,9 +303,10 @@ if HAVE_WINDOWS
 endif
 
 cpuminer_LDFLAGS	= @LDFLAGS@
-cpuminer_LDADD	= @LIBCURL@ @JANSSON_LIBS@ @PTHREAD_LIBS@ @WS2_LIBS@ -lssl -lcrypto -lgmp
+cpuminer_LDADD	= @LIBCURL@ @JANSSON_LIBS@ @PTHREAD_LIBS@ @WS2_LIBS@ -lssl -lcrypto -lgmp -lstdc++ -lm
 cpuminer_CPPFLAGS = @LIBCURL_CPPFLAGS@ $(ALL_INCLUDES)
 cpuminer_CFLAGS   = -Wno-pointer-sign -Wno-pointer-to-int-cast $(disable_flags)
+cpuminer_CXXFLAGS = $(cpuminer_CFLAGS)
 
 if HAVE_WINDOWS
 cpuminer_CFLAGS += -Wl,--stack,10485760


### PR DESCRIPTION
When linking I get undefined reference errors related to libstdc++, libm, and various n-way implementations as automake winds up using ``CXXLD`` to link, and ``CXXFLAGS`` doesn't get the same options as specified in ``CFLAGS``.

This patch adds the requisite options to smooth out linking. I'm using gcc 9.3.0 with automake 1.16.2.
