### PR TITLE
Honour --no-color consistently

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -1159,8 +1159,8 @@ void report_summary_log( bool force )
          applog2( LOG_MINR, "Count mismatch: %d, stats may be inaccurate",
                             mismatch );
       else if ( !opt_quiet )
-         applog2( LOG_INFO, CL_LBL
-                  "Count mismatch, submitted share may still be pending" CL_N );
+         applog2( LOG_INFO, "%sCount mismatch, submitted share may still be pending",
+                             use_colors ? CL_LBL : "" );
    }
 }
 
@@ -1294,7 +1294,7 @@ static int share_result( int result, struct work *work,
    const char *bell = !result && opt_bell ? &ASCII_BELL : "";
    applog( LOG_INFO, "%s%d %s%s %s%s %s%s %s%s%s, %.3f sec (%dms)",
            bell, my_stats.share_count, acol, ares, scol, sres, rcol, rres,
-           bcol, bres, CL_N, share_time, latency );
+           bcol, bres, use_colors ? CL_N : "", share_time, latency );
    if ( unlikely( !( opt_quiet || result || stale ) ) )
    {
       applog2( LOG_INFO, "%sReject reason: %s", bell, reason ? reason : "" );
@@ -1850,7 +1850,8 @@ bool submit_solution( struct work *work, const void *hash,
 {
 // Job went stale during hashing of a valid share.
 //   if ( !opt_quiet && work_restart[ thr->id ].restart )
-//      applog( LOG_INFO, CL_LBL "Share may be stale, submitting anyway..." CL_N );
+//      applog( LOG_INFO, "%sShare may be stale, submitting anyway...",
+//                        use_colors ? CL_LBL : "" );
    
    work->sharediff = hash_to_diff( hash );
    if ( likely( submit_work( thr, work ) ) )

--- a/util.c
+++ b/util.c
@@ -2653,7 +2653,7 @@ void applog_hash64(void *hash)
 }
 
 #define printpfx(n,h) \
-	printf("%s%11s%s: %s\n", CL_CYN, n, CL_N, format_hash(s, (uint8_t*) h))
+	printf("%s%11s%s: %s\n", use_colors ? CL_CYN : "", n, use_colors ? CL_N : "", format_hash(s, (uint8_t*) h))
 
 void print_hash_tests(void)
 {
@@ -2663,7 +2663,7 @@ void print_hash_tests(void)
         int algo;
 	scratchbuf = (uchar*) calloc(128, 1024);
 
-	printf(CL_WHT "CPU HASH ON EMPTY BUFFER RESULTS:" CL_N "\n\n");
+	printf("%sCPU HASH ON EMPTY BUFFER RESULTS:%s\n\n", use_colors ? CL_WHT : "", use_colors ? CL_N : "");
 
 	//buf[0] = 1; buf[64] = 2; // for endian tests
    for ( algo=0; algo < ALGO_COUNT; algo++ )


### PR DESCRIPTION
**Warning: I have not actually tested this change.**

I came across this bug while using cpuminer-opt-aurum with `--no-color` and found log lines like this:

```
[2024-01-15 13:43:42] 1 Accepted 1 S0 R0 B0<esc>[0m, 115.841 sec (194ms)
```

The bug for this line is in `share_result()` where CL_N is printed unconditionally rather than honouring `use_colors`.

However, while RE'ing the code, I found plenty of other cases where this could happen, as well as some unnecessary CL_N's at the end of strings (`applog()` and `applog2()` will emit CL_N at end-of-string when applicable).

Open to suggestions/recommendations, though please do not ask me to refactor all the code using stdout to "do it differently".  There's nothing beautiful about terminal sequences and no way to really make code for them clean/sane.  Just get 'er done.