### PR TITLE
Add CPUNet mining algorithm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -176,6 +176,7 @@ cpuminer_SOURCES = \
   algo/sha/sha256d.c \
   algo/sha/sha256d-4way.c \
   algo/sha/sha256t-gate.c \
+  algo/cpunet/cpunet-gate.c \
   algo/sha/sha256t-4way.c \
   algo/sha/sha256q-4way.c \
   algo/sha/sha256q.c \

--- a/algo-gate-api.c
+++ b/algo-gate-api.c
@@ -338,6 +338,7 @@ bool register_algo_gate( int algo, algo_gate_t *gate )
     case ALGO_SCRYPT:       rc = register_scrypt_algo        ( gate ); break;
     case ALGO_SHA256D:      rc = register_sha256d_algo       ( gate ); break;
     case ALGO_SHA256DT:     rc = register_sha256dt_algo      ( gate ); break;
+    case ALGO_CPUNET:       rc = register_cpunet_algo        ( gate ); break;
     case ALGO_SHA256Q:      rc = register_sha256q_algo       ( gate ); break;
     case ALGO_SHA256T:      rc = register_sha256t_algo       ( gate ); break;
     case ALGO_SHA3D:        rc = register_sha3d_algo         ( gate ); break;

--- a/algo/cpunet/cpunet-gate.c
+++ b/algo/cpunet/cpunet-gate.c
@@ -1,0 +1,25 @@
+#include "cpunet-gate.h"
+#include "../sha/sha256-hash.h"
+
+#include <string.h>
+#include <stdio.h>
+
+int cpunet_hash( void *hash, const void *data, int thr_id)
+{
+   static const uint8_t cpunet_suffix[7] = {'c', 'p', 'u', 'n', 'e', 't', '\0'};
+   uint8_t preimage[87];
+   uint8_t hash1[32];
+
+   memcpy(preimage, data, 80);
+   memcpy(preimage+80, cpunet_suffix, sizeof(cpunet_suffix));
+   sha256_full( hash1, preimage,  87 );
+   sha256_full( hash, hash1,  32 );
+   return 1;
+}
+
+bool register_cpunet_algo( algo_gate_t* gate )
+{
+   gate->optimizations = 0;
+   gate->hash = (void*)&cpunet_hash;
+   return true;
+}

--- a/algo/cpunet/cpunet-gate.h
+++ b/algo/cpunet/cpunet-gate.h
@@ -1,0 +1,11 @@
+#ifndef __CPUNET_GATE_H__
+#define __CPUNET_GATE_H__ 1
+
+#include <stdint.h>
+#include "algo-gate-api.h"
+
+bool register_cpunet_algo( algo_gate_t* gate );
+
+int cpunet_hash( void *hash, const void *data, int len );
+
+#endif

--- a/miner.h
+++ b/miner.h
@@ -624,6 +624,7 @@ enum algos {
         ALGO_SCRYPT,
         ALGO_SHA256D,
         ALGO_SHA256DT,
+        ALGO_CPUNET,
         ALGO_SHA256Q,
         ALGO_SHA256T,
         ALGO_SHA3D,
@@ -721,6 +722,7 @@ static const char* const algo_names[] = {
         "scrypt",
         "sha256d",
         "sha256dt",
+        "cpunet",
         "sha256q",
         "sha256t",
         "sha3d",
@@ -885,6 +887,7 @@ Options:\n\
                           scryptn2      scrypt(1048576, 1,1)\n\
                           sha256d       Double SHA-256\n\
                           sha256dt      Modified sha256d (Novo)\n\
+                          cpunet        SHA-256d with \"cpunet\\0\" appended\n\
                           sha256q       Quad SHA-256, Pyrite (PYE)\n\
                           sha256t       Triple SHA-256, Onecoin (OC)\n\
                           sha3d         Double Keccak256 (BSHA3)\n\


### PR DESCRIPTION
This is a simple modification to bitcoin's sha256d mining algorithm with the sole purpose of making existing ASICs unable to mine, for a more stable hashrate than bitcoin's TestNet4, and primarily for network latency measurements. CPUNet is a new test network for Bitcoin and Braidpool (a decentralized mining pool).

The CPUNet fork of bitcoin is here:
https://github.com/braidpool/bitcoin/tree/cpunet

The Braidpool code (under development) is here:
https://github.com/braidpool/braidpool